### PR TITLE
Correction of the RS‑resistor length calculation in Pcell/util.py

### DIFF
--- a/libs.tech/klayout/python/cells/util.py
+++ b/libs.tech/klayout/python/cells/util.py
@@ -381,7 +381,7 @@ def draw_res_p( cell, l, w ,
                layer = GR_layer):
     #
     m1_w    = co_w + 2 * co_e
-    res_len = l + co_w + 2 * co_e 
+    res_len = l + 2 * (co_w + co_e)
     #
     res_box = pya.DBox(-res_len/2.0, -w/2.0,  res_len/2.0, w/2.0 )
     #
@@ -391,13 +391,13 @@ def draw_res_p( cell, l, w ,
     #
     # Add CO
     # 
-    draw_cont( cell, y_size = w, x_disp = -l/2, layer = CO_layer )
-    draw_cont( cell, y_size = w, x_disp =  l/2, layer = CO_layer )
+    draw_cont( cell, y_size = w, x_disp = -l/2 - co_w/2, layer = CO_layer )
+    draw_cont( cell, y_size = w, x_disp =  l/2 + co_w/2, layer = CO_layer )
     #
     # Add M1
     # 
-    draw_metal( cell, x_size = m1_w, y_size = w, x_disp = -l/2, keep = False)
-    draw_metal( cell, x_size = m1_w, y_size = w, x_disp =  l/2, keep = False)
+    draw_metal( cell, x_size = m1_w, y_size = w, x_disp = -l/2 - co_w/2, keep = False)
+    draw_metal( cell, x_size = m1_w, y_size = w, x_disp =  l/2 + co_w/2, keep = False)
     #
 
 # ----- ------ ----- ----- ------ ----- ----- ------ ----- 


### PR DESCRIPTION
Change res_len equation for 'def draw_res_p' in Pcell util.py

For the Pcell res_poly instance with W=4um/L=20um,
- with original util.py
<img width="672" height="200" alt="image" src="https://github.com/user-attachments/assets/be374924-8959-40cf-9c6a-4fcc3267982d" />

- by this PR
<img width="732" height="247" alt="image" src="https://github.com/user-attachments/assets/d634da45-a3a3-4f31-a135-71b6584262f7" />

