### PR TITLE
Update TR-1um.lyt; define <connectivity> for Net Tracer

### DIFF
--- a/libs.tech/klayout/tech/TR-1um.lyt
+++ b/libs.tech/klayout/tech/TR-1um.lyt
@@ -156,5 +156,14 @@
   </mag>
  </writer-options>
  <connectivity>
+     <connection>DIFF,CO,M1</connection>
+     <connection>POLY,CO,M1</connection>
+     <connection>M1,TC,M2</connection>
+     <symbols>DIFF='3/1+3/2-8/1'</symbols>
+     <symbols>POLY='8/1'</symbols>
+     <symbols>CO='11/0'</symbols>
+     <symbols>M1='13/0'</symbols>
+     <symbols>TC='19/0'</symbols>
+     <symbols>M2='20/0'</symbols>
  </connectivity>
 </technology>


### PR DESCRIPTION
Define `<connectivity>` rules for Klayout Net Tracer 
<img width="763" height="758" alt="image" src="https://github.com/user-attachments/assets/350a946e-d084-4297-9ce2-61898e32d9f4" />

For fix #69 