### PR TITLE
Update 02_Extract.lvs and 05_Compare.lvs

### DIFF
--- a/libs.tech/klayout/tech/lvs/02_Extract.lvs
+++ b/libs.tech/klayout/tech/lvs/02_Extract.lvs
@@ -20,6 +20,7 @@ class LWCapacitorWithBulk < RBA::DeviceClassCapacitorWithBulk
     self.combiner = CAPDeviceCombiner.new
     self.supports_serial_combination = false
     self.supports_parallel_combination = true
+    clear_equivalent_terminal_ids
   end
 end
 #

--- a/libs.tech/klayout/tech/lvs/05_Compare.lvs
+++ b/libs.tech/klayout/tech/lvs/05_Compare.lvs
@@ -82,7 +82,10 @@ else
     else
         puts("Starting TR-1um LVS Comparison in strict port mode")
         puts("flag_missing_ports enabled: missing/mislabeled top-level ports are treated as errors")
-        success = compare && flag_missing_ports
+        # success = compare && flag_missing_ports
+        compare_result = compare
+        port_check_result = flag_missing_ports
+        success = compare_result && port_check_result
     end
     #================================================
     #------------- COMPARISON RESULTS ---------------


### PR DESCRIPTION
prevent CSIO terminal swapping
always check ports (previously only checked ports if compare succeeded

Fixes #91 